### PR TITLE
new template for opensuse 42.2

### DIFF
--- a/openSUSE-42.2/http/autoinst.xml
+++ b/openSUSE-42.2/http/autoinst.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+
+<!-- http://doc.opensuse.org/projects/autoyast/configuration.html -->
+
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+            <forceboot config:type="boolean">true</forceboot>
+            <final_reboot config:type="boolean">false</final_reboot>
+        </mode>
+    </general>
+    <report>
+        <messages>
+            <show config:type="boolean">false</show>
+            <timeout config:type="integer">10</timeout>
+            <log config:type="boolean">true</log>
+        </messages>
+        <warnings>
+            <show config:type="boolean">false</show>
+            <timeout config:type="integer">10</timeout>
+            <log config:type="boolean">true</log>
+        </warnings>
+        <errors>
+            <show config:type="boolean">false</show>
+            <timeout config:type="integer">10</timeout>
+            <log config:type="boolean">true</log>
+        </errors>
+    </report>
+
+    <keyboard>
+        <keymap>english-us</keymap>
+    </keyboard>
+    <language>
+        <language>en_US</language>
+        <languages>en_US</languages>
+    </language>
+    <timezone>
+        <hwclock>UTC</hwclock>
+        <timezone>UTC</timezone>
+    </timezone>
+
+    <partitioning config:type="list">
+        <drive>
+            <device>/dev/sda</device>
+            <initialize config:type="boolean">true</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <label>boot</label>
+                    <mount>/boot</mount>
+                    <mountby config:type="symbol">label</mountby>
+                    <partition_type>primary</partition_type>
+                    <size>200M</size>
+                </partition>
+                <partition>
+                    <label>system</label>
+                    <lvm_group>system</lvm_group>
+                    <partition_type>primary</partition_type>
+                    <size>max</size>
+                </partition>
+            </partitions>
+            <use>all</use>
+        </drive>
+        <drive>
+            <device>/dev/system</device>
+            <initialize config:type="boolean">true</initialize>
+            <is_lvm_vg config:type="boolean">true</is_lvm_vg>
+            <partitions config:type="list">
+                <partition>
+                    <label>swap</label>
+                    <mountby config:type="symbol">label</mountby>
+                    <filesystem config:type="symbol">swap</filesystem>
+                    <lv_name>swap</lv_name>
+                    <mount>swap</mount>
+                    <size>2G</size>
+                </partition>
+                <partition>
+                    <label>root</label>
+                    <mountby config:type="symbol">label</mountby>
+                    <filesystem config:type="symbol">ext4</filesystem>
+                    <lv_name>root</lv_name>
+                    <mount>/</mount>
+                    <size>max</size>
+                </partition>
+            </partitions>
+            <pesize>4M</pesize>
+            <type config:type="symbol">CT_LVM</type>
+            <use>all</use>
+        </drive>
+    </partitioning>
+
+    <bootloader>
+        <loader_type>grub2</loader_type>
+    </bootloader>
+
+    <networking>
+        <ipv6 config:type="boolean">false</ipv6>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+        <dns>
+            <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+            <dhcp_resolv config:type="boolean">true</dhcp_resolv>
+            <domain>local</domain>
+            <hostname>linux</hostname>
+        </dns>
+        <interfaces config:type="list">
+            <interface>
+                <bootproto>dhcp</bootproto>
+                <device>eth0</device>
+                <startmode>onboot</startmode>
+            </interface>
+        </interfaces>
+    </networking>
+
+    <firewall>
+        <enable_firewall config:type="boolean">false</enable_firewall>
+        <start_firewall config:type="boolean">false</start_firewall>
+    </firewall>
+
+    <software>
+        <image/>
+	<instsource>http://download.opensuse.org/distribution/leap/42.2/repo/oss/</instsource>
+        <do_online_update config:type="boolean">true</do_online_update>
+        <kernel>kernel-default</kernel>
+        <patterns config:type="list">
+            <pattern>base</pattern>
+        </patterns>
+        <packages config:type="list">
+            <package>kernel-default-devel</package>
+            <package>gcc</package>
+            <package>glibc-locale</package>
+            <package>grub2</package>
+            <package>make</package>
+            <package>iproute2</package>
+            <package>ntp</package>
+            <package>openssh</package>
+            <package>procps</package>
+            <package>sudo</package>
+            <package>vim-data</package>
+            <package>yast2-hardware-detection</package>
+            <package>yast2-users</package>
+            <package>zypper</package>
+            <package>bash</package>
+            <package>puppet</package>
+            <package>autoyast2-installation</package>
+            <package>autoyast2</package>
+            <package>yast2-installation</package>
+            <package>yast2-network</package>
+						<package>yast2-theme-openSUSE</package>
+						<package>iputils</package>
+						<package>vim</package>
+        </packages>
+        <remove-packages config:type="list">
+            <package>desktop-translations</package>
+            <package>kernel-firmware</package>
+            <package>virtualbox-guest-kmp-default</package>
+            <package>virtualbox-guest-tools</package>
+            <package>yast2-branding-openSUSE</package>
+        </remove-packages>
+    </software>
+
+    <runlevel>
+        <default>3</default>
+        <services config:type="list">
+            <service>
+                <service_name>ntp</service_name>
+                <service_status>enable</service_status>
+            </service>
+            <service>
+                <service_name>sshd</service_name>
+                <service_status>enable</service_status>
+            </service>
+        </services>
+    </runlevel>
+
+    <groups config:type="list">
+        <group>
+            <gid>100</gid>
+            <groupname>users</groupname>
+            <userlist/>
+        </group>
+    </groups>
+
+    <user_defaults>
+        <expire/>
+        <group>100</group>
+        <groups/>
+        <home>/home</home>
+        <inactive>-1</inactive>
+        <no_groups config:type="boolean">true</no_groups>
+        <shell>/bin/bash</shell>
+        <skel>/etc/skel</skel>
+        <umask>022</umask>
+    </user_defaults>
+
+    <users config:type="list">
+        <user>
+            <user_password>vagrant</user_password>
+            <username>root</username>
+        </user>
+        <user>
+            <fullname>vagrant</fullname>
+            <gid>100</gid>
+            <home>/home/vagrant</home>
+            <password_settings>
+                <expire/>
+                <flag/>
+                <inact>-1</inact>
+                <max>99999</max>
+                <min>0</min>
+                <warn>7</warn>
+            </password_settings>
+            <shell>/bin/bash</shell>
+            <uid>1000</uid>
+            <user_password>vagrant</user_password>
+            <username>vagrant</username>
+        </user>
+    </users>
+    <kdump>
+        <add_crash_kernel config:type="boolean">false</add_crash_kernel>
+    </kdump>
+</profile>

--- a/openSUSE-42.2/scripts/postinstall.sh
+++ b/openSUSE-42.2/scripts/postinstall.sh
@@ -1,0 +1,49 @@
+#
+# postinstall.sh
+#
+
+date > /etc/vagrant_box_build_time
+
+# remove zypper package locks
+rm -f /etc/zypp/locks
+
+# install required packages
+#packages=( gcc make kernel-devel vim )
+#zypper --non-interactive install --no-recommends --force-resolution ${packages[@]}
+
+# install vagrant key
+mkdir -pm 700 /home/vagrant/.ssh
+curl -Lo /home/vagrant/.ssh/authorized_keys 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant: /home/vagrant/.ssh
+
+# set vagrant sudo
+printf "%b" "
+# added by packer postinstall.sh
+vagrant ALL=(ALL) NOPASSWD: ALL
+" >> /etc/sudoers
+
+# speed-up remote logins
+printf "%b" "
+# added by packer postinstall.sh
+UseDNS no
+" >> /etc/ssh/sshd_config
+
+# disable gem docs
+echo "gem: --no-ri --no-rdoc" >/etc/gemrc
+
+# backlist i2c_piix4 - VirtualBox has no smbus
+echo "blacklist i2c_piix4" > /etc/modprobe.d/100-blacklist-i2c_piix4.conf
+
+# put shutdown command in path
+ln -s /sbin/shutdown /usr/bin/shutdown
+
+# ntp servers
+printf "%b" "
+# added by packer postinstall.sh
+server 0.de.pool.ntp.org
+server 1.de.pool.ntp.org
+server 2.de.pool.ntp.org
+server 3.de.pool.ntp.org
+" >> /etc/ntp.conf
+

--- a/openSUSE-42.2/scripts/virtualbox.sh
+++ b/openSUSE-42.2/scripts/virtualbox.sh
@@ -1,0 +1,9 @@
+# Installing the virtualbox guest additions
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+cd /tmp
+mount -o loop /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt || echo "unable to mount virtual box guest addtions iso"
+sh /mnt/VBoxLinuxAdditions.run install --force || echo "unable to install driver"
+umount /mnt || echo "unable to umount iso"
+rm -rf /home/vagrant/VBoxGuestAdditions_*.iso || echo "unable to rm iso"
+echo "guest additions installed"
+

--- a/openSUSE-42.2/scripts/zerodisk.sh
+++ b/openSUSE-42.2/scripts/zerodisk.sh
@@ -1,0 +1,5 @@
+# Zero out the free space to save space in the final image:
+rm -rf /home/vagrant/*.sh
+rm -rf /home/vagrant/.v*
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/openSUSE-42.2/template.json
+++ b/openSUSE-42.2/template.json
@@ -1,0 +1,88 @@
+{
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/postinstall.sh",
+        "scripts/virtualbox.sh",
+        "scripts/zerodisk.sh"
+      ],
+      "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'"
+    }
+  ],
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "<esc><enter><wait>",
+        "linux netdevice=eth0 netsetup=dhcp<wait>",
+        " install=http://download.opensuse.org/distribution/leap/42.2/repo/oss/ <wait>",
+        " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/autoinst.xml<wait>",
+        " textmode=1<wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 20480,
+      "guest_os_type": "OpenSUSE_64",
+      "http_directory": "http",
+      "iso_checksum": "750434ff041b9e7baf31217fcfab41df0560e8e8a39d508c196eb19c151f265c",
+      "iso_checksum_type": "sha256",
+      "iso_url": "http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-x86_64.iso",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo '/sbin/shutdown -P now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'",
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "virtualbox_version_file": ".vbox_version",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "1024"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "2"
+        ]
+      ]
+    },
+    {
+      "type": "vmware-iso",
+      "boot_command": [
+        "<esc><enter><wait>",
+        "linux netdevice=ens33 netsetup=dhcp<wait>",
+        " install=http://download.opensuse.org/distribution/leap/42.2/repo/oss/ insecure=1<wait>",
+        " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/autoinst.xml<wait>",
+        " textmode=1<wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 20480,
+      "guest_os_type": "opensuse-64",
+      "http_directory": "http",
+      "iso_checksum": "750434ff041b9e7baf31217fcfab41df0560e8e8a39d508c196eb19c151f265c",
+      "iso_checksum_type": "sha256",
+      "iso_url": "http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-x86_64.iso",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo '/sbin/shutdown -P now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'",
+      "vmx_data": {
+        "memsize": "1024",
+        "numvcpus": "2",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "openSUSE-42.2-{{ .Provider }}.box"
+    }
+  ]
+}


### PR DESCRIPTION
recursively copied 42.1 directory to 42.2

in 42.2 directory, migrated all references from 42.1 to 42.2

successfully tested locally using: 
macOS 10.12.2
vagrant 1.9.1
packer 0.12.1
virtualbox 5.1.12 r112440
 